### PR TITLE
improve request retry logic

### DIFF
--- a/requests_lb/__init__.py
+++ b/requests_lb/__init__.py
@@ -1,1 +1,1 @@
-VERSION='0.2.3'
+VERSION = '0.3.0'

--- a/requests_lb/requests_lb.py
+++ b/requests_lb/requests_lb.py
@@ -173,7 +173,6 @@ class RequestsLB:
         return _fn
 
     def request(self, method, target, **kw):
-        req = self._s.request
         fn = self._request_fn(method)
         return self._retry_request(fn, target, **kw)
 

--- a/requests_lb/requests_lb.py
+++ b/requests_lb/requests_lb.py
@@ -46,7 +46,6 @@ class RequestsLB:
         self._srv = kw.get('srv_provider', srv_provider)(**kw)
         self._sample = kw.get('sample_provider', sample_provider)
         self._srv_update_timeout = kw.get('srv_timeout', 30)
-        self._timeout = kw.get('request_timeout', 30)
         self._bad_host_timeout = kw.get('bad_host_timeout', 2)
 
         self._srv_host = None
@@ -139,15 +138,10 @@ class RequestsLB:
         if target[0] == '/':
             target = target[1:]
 
-        start = self._time()
-
         while True:
             host_entry = self._srv_next_host()
             (host, port) = host_entry
             url = "{}://{}:{}/{}".format(self._protocol, host, port, target)
-
-            params = dict(kw)
-            params['timeout'] = (self._timeout - (self._time() - start))
 
             try:
                 response = fn(url, **kw)


### PR DESCRIPTION
improve request retry logic
* Have a default of 3 retries for a request


I'm working on making the service level tracker being built internally be more resilient and clearer around errors that can occur. The heroic-api library uses this library so I have a few changes to make here first. 

When testing this internally I decided to go with a max request retries rather than a timeout given the amount of hosts returned from some SRV lookups, e.g. it will cycle through all of them very quickly.

This bumps the version to 0.3.0