### PR TITLE
Bump versions of requests and dnspython

### DIFF
--- a/requests_lb/__init__.py
+++ b/requests_lb/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.3.0'
+VERSION = '0.3.1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-dnspython3==1.14.0
+dnspython3==1.15.0
 requests==2.18.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-dnspython3==1.12.0
-requests==2.9.1
+dnspython3==1.14.0
+requests==2.18.4

--- a/requirements2.txt
+++ b/requirements2.txt
@@ -1,2 +1,2 @@
-dnspython==1.12.0
-requests==2.9.1
+dnspython==1.14.0
+requests==2.18.4

--- a/requirements2.txt
+++ b/requirements2.txt
@@ -1,2 +1,2 @@
-dnspython==1.14.0
+dnspython==1.15.0
 requests==2.18.4


### PR DESCRIPTION
bumping requirements versions as this is too old.
Most libraries around it have been updated in a
non retro compatible way.